### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Follow us on twitter: [@Codeminer42](https://twitter.com/Codeminer42)
 
 ## Development requirements
 
-* Cocoapods - https://github.com/CocoaPods/CocoaPods
+* CocoaPods - https://github.com/CocoaPods/CocoaPods
 
 ## Install cocoapods
 
@@ -23,7 +23,7 @@ More information about cocoapods:
 * https://github.com/CocoaPods/CocoaPods
 * http://nsscreencast.com/episodes/5-cocoapods
 
-## Cocoapods
+## CocoaPods
 
 Add the dependency to your `Podfile`:
 


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
